### PR TITLE
Update kopijahe : menambah uji ping ke dns server

### DIFF
--- a/scripts/kopijahe
+++ b/scripts/kopijahe
@@ -502,46 +502,55 @@ captiveportalcheck() {
 	# KopiJahe: Layanan cek captive portal bawaan script
 	if [[ "$cpcprovider" = "kopijahe" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://periksakoneksi.kopijahe.my.id/cek")"
+		dnsserver="208.67.222.222"
 		kodestatuslanding="$?"
 		hasil="OK"
 	# Firefox: Layanan cek captive portal bawaan browser Mozilla Firefox
 	elif [[ "$cpcprovider" = "firefox" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://detectportal.firefox.com/success.txt")"
+		dnsserver="208.67.220.220"
 		kodestatuslanding="$?"
 		hasil="success"
 	# Google: Layanan cek captive portal bawaan sistem operasi android
 	elif [[ "$cpcprovider" = "google" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://connectivitycheck.gstatic.com/generate_204" | grep -o "204")"
+		dnsserver="8.8.4.4"
 		kodestatuslanding="$?"
 		hasil="204"
 	# Google2: Layanan cek captive portal bawaan chrome
 	elif [[ "$cpcprovider" = "google2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://clients3.google.com/generate_204" | grep -o "204")"
+		dnsserver="8.8.8.8"
 		kodestatuslanding="$?"
 		hasil="204"
 	# Apple: Layanan cek captive portal bawaan perangkat Apple
 	elif [[ "$cpcprovider" = "apple" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://captive.apple.com/" | grep -o "Success" | head -c8)"
+		dnsserver="1.0.0.1"
 		kodestatuslanding="$?"
 		hasil="Success"
 	# Apple2: Layanan cek captive portal alternatif perangkat Apple
 	elif [[ "$cpcprovider" = "apple2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "https://www.apple.com/library/test/success.html" | grep -o "Success" | head -c8)"
+		dnsserver="9.9.9.9"
 		kodestatuslanding="$?"
 		hasil="Success"
 	# Microsoft2: Layanan cek captive portal alternatif milik Microsoft
 	elif [[ "$cpcprovider" = "microsoft2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://www.msftncsi.com/ncsi.txt")"
+		dnsserver="208.67.222.123"
 		kodestatuslanding="$?"
 		hasil="Microsoft NCSI"
 	# Microsoft: Layanan cek captive portal bawaan sistem operasi Windows
 	elif [[ "$cpcprovider" = "microsoft" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://www.msftconnecttest.com/connecttest.txt")"
+		dnsserver="208.67.220.123"
 		kodestatuslanding="$?"
 		hasil="Microsoft Connect Test"
 	# Xiaomi: Layanan cek captive portal bawaan sistem operasi MIUI
 	elif [[ "$cpcprovider" = "xiaomi" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://connect.rom.miui.com/generate_204" | grep -o "204")"
+		dnsserver="77.88.8.8"
 		kodestatuslanding="$?"
 		hasil="204"
 	fi
@@ -553,9 +562,18 @@ captiveportalcheck() {
 		cpcstatus="Sukses"
 	# Jika hasilnya tidak sama, maka:
 	else
+		# lakukan test ping ke dns server sesuai pilihan penyedia captive portal
+		testping="$(ping -I "$wandevice" -c 2 $dnsserver)"
+		testping=$?
+		if [[ "$testping" == 0 ]]; then
+		# Tentukan bahwa terkoneksi dengan internet
+		internetconnected="yes"
+		cpcstatus="Sukses"
+		else
 		# Tentukan bahwa tidak terkoneksi dengan internet
 		internetconnected="no"
 		cpcstatus="Gagal"
+		fi
 	fi	
 	
 	# Jika kode status hasil cek koneksi adalah 127, maka:

--- a/scripts/kopijahe
+++ b/scripts/kopijahe
@@ -17,7 +17,7 @@ touch /etc/config/kopijahe
 versi() {
 	# Fungsi versi aplikasi
 	# Tentukan versi dengan mengubah variabel "ver"
-	ver="1.9.7"
+	ver="1.9.8"
 }
 
 bantuan() {
@@ -497,62 +497,71 @@ captiveportalcheck() {
 		cpctimeout="3"
 	fi	
 	
+	# Daftar IP server DNS publik (untuk pengecekan cadangan menggunakan ping jika gagal mengecek menggunakan curl)
+	dnsgoogle="8.8.8.8"
+	dnsgoogle2="8.8.4.4"
+	dnsopendns="208.67.222.222"
+	dnsopendns2="208.67.220.220"
+	dnscloudflare="1.1.1.1"
+	dnscloudflare2="1.0.0.1"
+	dnsquad9="9.9.9.9"
+	
 	# Daftar penyedia layanan cek captive portal beserta hasil cek yang diharapkan
 	# 
 	# KopiJahe: Layanan cek captive portal bawaan script
 	if [[ "$cpcprovider" = "kopijahe" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://periksakoneksi.kopijahe.my.id/cek")"
-		dnsserver="208.67.222.222"
 		kodestatuslanding="$?"
 		hasil="OK"
+		dnsserver="$dnsopendns"
 	# Firefox: Layanan cek captive portal bawaan browser Mozilla Firefox
 	elif [[ "$cpcprovider" = "firefox" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://detectportal.firefox.com/success.txt")"
-		dnsserver="208.67.220.220"
 		kodestatuslanding="$?"
 		hasil="success"
+		dnsserver="$dnsopendns2"
 	# Google: Layanan cek captive portal bawaan sistem operasi android
 	elif [[ "$cpcprovider" = "google" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://connectivitycheck.gstatic.com/generate_204" | grep -o "204")"
-		dnsserver="8.8.4.4"
 		kodestatuslanding="$?"
 		hasil="204"
+		dnsserver="$dnsgoogle"
 	# Google2: Layanan cek captive portal bawaan chrome
 	elif [[ "$cpcprovider" = "google2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://clients3.google.com/generate_204" | grep -o "204")"
-		dnsserver="8.8.8.8"
 		kodestatuslanding="$?"
 		hasil="204"
+		dnsserver="$dnsgoogle2"
 	# Apple: Layanan cek captive portal bawaan perangkat Apple
 	elif [[ "$cpcprovider" = "apple" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://captive.apple.com/" | grep -o "Success" | head -c8)"
-		dnsserver="1.0.0.1"
 		kodestatuslanding="$?"
 		hasil="Success"
+		dnsserver="$dnscloudflare"
 	# Apple2: Layanan cek captive portal alternatif perangkat Apple
 	elif [[ "$cpcprovider" = "apple2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "https://www.apple.com/library/test/success.html" | grep -o "Success" | head -c8)"
-		dnsserver="9.9.9.9"
 		kodestatuslanding="$?"
 		hasil="Success"
+		dnsserver="$dnscloudflare2"
 	# Microsoft2: Layanan cek captive portal alternatif milik Microsoft
 	elif [[ "$cpcprovider" = "microsoft2" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://www.msftncsi.com/ncsi.txt")"
-		dnsserver="208.67.222.123"
 		kodestatuslanding="$?"
 		hasil="Microsoft NCSI"
+		dnsserver="$dnsopendns"
 	# Microsoft: Layanan cek captive portal bawaan sistem operasi Windows
 	elif [[ "$cpcprovider" = "microsoft" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -L --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://www.msftconnecttest.com/connecttest.txt")"
-		dnsserver="208.67.220.123"
 		kodestatuslanding="$?"
 		hasil="Microsoft Connect Test"
+		dnsserver="$dnsquad9"
 	# Xiaomi: Layanan cek captive portal bawaan sistem operasi MIUI
 	elif [[ "$cpcprovider" = "xiaomi" ]]; then
 		cekkoneksi="$(curl --interface "$wandevice" -LI --silent --retry $cpcretry --max-redirs 1 --connect-timeout $cpctimeout "http://connect.rom.miui.com/generate_204" | grep -o "204")"
-		dnsserver="77.88.8.8"
 		kodestatuslanding="$?"
 		hasil="204"
+		dnsserver="$dnsquad9"
 	fi
 	
 	# Jika hasil cek koneksi sesuai dengan hasil yang diharapkan, maka:
@@ -560,20 +569,20 @@ captiveportalcheck() {
 		# Tentukan bahwa terkoneksi dengan internet
 		internetconnected="yes"
 		cpcstatus="Sukses"
-		
-	# Jika hasilnya tidak sama, maka:
-	else
-		# lakukan test ping ke dns server sesuai pilihan penyedia captive portal
-		testping="$(ping -I "$wandevice" -c 2 $dnsserver)"
-		testping=$?
-		if [[ "$testping" == 0 ]]; then
-		# Tentukan bahwa terkoneksi dengan internet
-		internetconnected="yes"
-		cpcstatus="Sukses"
+	# Jika hasilnya tidak sama dan bukan mode tes penyedia jasa koneksi, maka:
+	elif [[ "$cekkoneksi" != "$hasil" ]] && [[ "$cpcprovider" != "test" ]]; then
+		# Lakukan cek menggunakan ping terlebih dahulu ke dns server sesuai pilihan penyedia captive portal
+		cekkoneksiping="$(ping -I "$wandevice" -c $cpcretry $dnsserver)"
+		cekkoneksiping="$?"
+		# Jika ping berhasil, maka:
+		if [[ "$cekkoneksiping" = "0" ]]; then
+			# Tentukan bahwa terkoneksi dengan internet
+			internetconnected="yes"
+			cpcstatus="Sukses"
 		else
-		# Tentukan bahwa tidak terkoneksi dengan internet
-		internetconnected="no"
-		cpcstatus="Gagal"
+			# Tentukan bahwa tidak terkoneksi dengan internet
+			internetconnected="no"
+			cpcstatus="Gagal"
 		fi
 	fi	
 	
@@ -1107,10 +1116,6 @@ while [[ "$advancedmode" = "" ]]; do
 			sleep "$sleeptime"
 		fi
 	else
-		# Catat jam dan tanggal saat ini di berkas "/tmp/last.login.$waninterface"
-		date > "/tmp/last.login.$waninterface"
-		# Catat percobaan login terakhir di berkas "/tmp/last.login.$waninterface"
-		echo "Tes Koneksi sukses" >> "/tmp/last.login.$waninterface"
 		# Istirahat sebelum coba mengecek koneksi kembali
 		sleep "$sleeptime"
 	fi

--- a/scripts/kopijahe
+++ b/scripts/kopijahe
@@ -560,6 +560,7 @@ captiveportalcheck() {
 		# Tentukan bahwa terkoneksi dengan internet
 		internetconnected="yes"
 		cpcstatus="Sukses"
+		
 	# Jika hasilnya tidak sama, maka:
 	else
 		# lakukan test ping ke dns server sesuai pilihan penyedia captive portal
@@ -1106,6 +1107,10 @@ while [[ "$advancedmode" = "" ]]; do
 			sleep "$sleeptime"
 		fi
 	else
+		# Catat jam dan tanggal saat ini di berkas "/tmp/last.login.$waninterface"
+		date > "/tmp/last.login.$waninterface"
+		# Catat percobaan login terakhir di berkas "/tmp/last.login.$waninterface"
+		echo "Tes Koneksi sukses" >> "/tmp/last.login.$waninterface"
 		# Istirahat sebelum coba mengecek koneksi kembali
 		sleep "$sleeptime"
 	fi


### PR DESCRIPTION
- add dns server for each captive portal check ( based on adguard kb article )
- if captive portal check was failed then do ping request to dns server, before declaring that internet connection was lost.
